### PR TITLE
Port nadir to Qt5 and fix overlay bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,12 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 project(nadir)
 
-find_package(Qt4 REQUIRED)
-include( ${QT_USE_FILE} )
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+find_package(Qt5 REQUIRED COMPONENTS Widgets LinguistTools)
 
 MESSAGE(STATUS "Looking for libasound2")
 find_library(ASOUND2_LIBRARY asound)

--- a/README
+++ b/README
@@ -15,7 +15,7 @@ screen and virtually produce any mouse event (click, drag...) in that location.
   - Making a certain movement (head or body) by using a webcam (NOT IMPLEMENTED)
   - Producing a sound by using a microphone
 
-  This software is being developed with C++, Qt4 and OpenCV
+  This software is being developed with C++, Qt5 and OpenCV
 
   Desktop: X11 Operating system: All POSIX Development: Pre-Alpha
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,12 +44,12 @@ set(RC_FILES
       translations/nadir_es.ts
    )
 
-qt4_wrap_cpp(MOC_SOURCES ${HEADERS})
-qt4_wrap_ui(UI_HEADERS ${UI_FILES})
-qt4_add_resources(RC_SOURCES ${RC_FILES})
+qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
+qt5_wrap_ui(UI_HEADERS ${UI_FILES})
+qt5_add_resources(RC_SOURCES ${RC_FILES})
 include_directories(${CMAKE_BINARY_DIR}/src)
 
-QT4_CREATE_TRANSLATION(TRANSLATION ${TS_FILES})
+qt5_create_translation(TRANSLATION ${TS_FILES})
 
 add_executable(nadir
                  ${SOURCES}
@@ -59,8 +59,8 @@ add_executable(nadir
                  ${TRANSLATION}
               )
 
-target_link_libraries(nadir 
-                 ${QT_LIBRARIES}
+target_link_libraries(nadir
+                 Qt5::Widgets
                  ${ASOUND2_LIBRARY}
                  ${JACK_LIBRARY}
                  ${X11_LIBRARY}

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -17,7 +17,7 @@
  * along with Nadir.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include <QtGui>
+#include <QtWidgets>
 #include <QColorDialog>
 #include <QSettings>
 #include <QStringList>

--- a/src/confWidget.h
+++ b/src/confWidget.h
@@ -20,7 +20,7 @@
 #ifndef CONFWIDGET_H
 #define CONFWIDGET_H
 
-#include <QtGui/QWidget>
+#include <QtWidgets/QWidget>
 #include <QMainWindow>
 #include <QWidget>
 #include <math.h>

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -17,8 +17,7 @@
  * along with Nadir.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include <QtGui>
-#include <QSound>
+#include <QtWidgets>
 #include "mainWidget.h"
 
 MainWidget::MainWidget()
@@ -49,8 +48,8 @@ MainWidget::MainWidget()
   trayIcon = NULL;
   firstConf = true;
 
-  hLine = new ScanLine( this, HORIZONTAL, kbd );
-  vLine = new ScanLine( this, VERTICAL, kbd );
+  hLine = new ScanLine( nullptr, HORIZONTAL, kbd );
+  vLine = new ScanLine( nullptr, VERTICAL, kbd );
 
   scanTimer = new QTimer(this);
   connect(scanTimer, SIGNAL(timeout()), this, SLOT( grabEvent() ));

--- a/src/scanLine.cpp
+++ b/src/scanLine.cpp
@@ -17,7 +17,7 @@
  * along with Nadir.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include <QtGui>
+#include <QtWidgets>
 #include <QDesktopWidget>
 #include "mainWidget.h"
 #include "scanLine.h"
@@ -29,6 +29,7 @@ ScanLine::ScanLine( QWidget *parent, lineType type, Keyboard *kbd ):
   flags |= Qt::ToolTip;
   flags |= Qt::WindowStaysOnTopHint;
   flags |= Qt::FramelessWindowHint;
+  flags |= Qt::X11BypassWindowManagerHint;
   setWindowFlags( flags );
   setAttribute( Qt::WA_ShowWithoutActivating );
   setFocusPolicy( Qt::NoFocus );

--- a/src/scanLine.h
+++ b/src/scanLine.h
@@ -21,7 +21,7 @@
 #define SCANLINE_H
 
 #include <QMainWindow>
-#include <QtGui/QWidget>
+#include <QtWidgets/QWidget>
 #include <QTimer>
 #include <QWidget>
 #include <X11/Xlib.h>


### PR DESCRIPTION
## Summary
- update CMake to use Qt5 and enable automoc
- update build rules for Qt5
- adjust includes for Qt5 modules
- show scan lines on modern compositors
- mention Qt5 in README

## Testing
- `cmake ..` *(fails: could not find Qt5)*
- `make` *(fails: no makefile generated)*

------
https://chatgpt.com/codex/tasks/task_e_6887add7a598832e9a6bf1a30d4db6b3