### PR TITLE
Port nadir to Qt5 and fix overlay bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,15 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 project(nadir)
 
-find_package(Qt4 REQUIRED)
-include( ${QT_USE_FILE} )
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+find_package(Qt5 REQUIRED COMPONENTS Widgets LinguistTools)
 
 MESSAGE(STATUS "Looking for libasound2")
 find_library(ASOUND2_LIBRARY asound)

--- a/README
+++ b/README
@@ -15,7 +15,7 @@ screen and virtually produce any mouse event (click, drag...) in that location.
   - Making a certain movement (head or body) by using a webcam (NOT IMPLEMENTED)
   - Producing a sound by using a microphone
 
-  This software is being developed with C++, Qt4 and OpenCV
+  This software is being developed with C++, Qt5 and OpenCV
 
   Desktop: X11 Operating system: All POSIX Development: Pre-Alpha
 
@@ -35,7 +35,7 @@ INSTALL
 - Dependencies (packages names may change depending on your system):
 
     cmake          - A cross-platform, open-source make system
-    libqt4-dev     - Qt 4 development files
+    qtbase5-dev    - Qt 5 development files
     libjack-dev    - JACK Audio Connection Kit (development files)
     libasound2-dev - ALSA library development files
     libxtst-dev    - X11 Record extension library (development files)
@@ -51,7 +51,7 @@ INSTALL
 
     # make install
 
-- Unnstalling the application (as root):
+- Uninstalling the application (as root):
 
     # make uninstall
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,12 +44,12 @@ set(RC_FILES
       translations/nadir_es.ts
    )
 
-qt4_wrap_cpp(MOC_SOURCES ${HEADERS})
-qt4_wrap_ui(UI_HEADERS ${UI_FILES})
-qt4_add_resources(RC_SOURCES ${RC_FILES})
+qt5_wrap_cpp(MOC_SOURCES ${HEADERS})
+qt5_wrap_ui(UI_HEADERS ${UI_FILES})
+qt5_add_resources(RC_SOURCES ${RC_FILES})
 include_directories(${CMAKE_BINARY_DIR}/src)
 
-QT4_CREATE_TRANSLATION(TRANSLATION ${TS_FILES})
+qt5_create_translation(TRANSLATION ${TS_FILES})
 
 add_executable(nadir
                  ${SOURCES}
@@ -59,8 +59,8 @@ add_executable(nadir
                  ${TRANSLATION}
               )
 
-target_link_libraries(nadir 
-                 ${QT_LIBRARIES}
+target_link_libraries(nadir
+                 Qt5::Widgets
                  ${ASOUND2_LIBRARY}
                  ${JACK_LIBRARY}
                  ${X11_LIBRARY}

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -17,11 +17,12 @@
  * along with Nadir.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include <QtGui>
+#include <QtWidgets>
 #include <QColorDialog>
 #include <QSettings>
 #include <QStringList>
 #include "confWidget.h"
+#include "mainWidget.h"
 
 ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd ):
   QWidget( parent )
@@ -33,31 +34,32 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd ):
   ui.tabWidget->removeTab(2);
   ui.tabWidget->removeTab(3);
 
-  connect( ui.colorButton, SIGNAL(clicked()),
-      this, SLOT(setColor()) );
+  connect(ui.colorButton, &QPushButton::clicked,
+          this, &ConfWidget::setColor);
 
-  connect( ui.cancelButton, SIGNAL(clicked()),
-      this, SLOT(close()) );
+  connect(ui.cancelButton, &QPushButton::clicked,
+          this, &ConfWidget::close);
 
-  connect( ui.saveButton, SIGNAL(clicked()),
-      this, SLOT(save()) );
+  connect(ui.saveButton, &QPushButton::clicked,
+          this, &ConfWidget::save);
 
-  connect( this, SIGNAL(closing()),
-      parentWidget(), SLOT(reloadSettings()) );
+  if(auto parent = qobject_cast<MainWidget*>(parentWidget()))
+      connect(this, &ConfWidget::closing,
+              parent, &MainWidget::reloadSettings);
 
-  connect(ui.minimizedBox, SIGNAL(toggled(bool)),
-      this, SLOT(minimizedBoxToggled()));
+  connect(ui.minimizedBox, &QCheckBox::toggled,
+          this, &ConfWidget::minimizedBoxToggled);
 
-  connect(ui.hiddenBox, SIGNAL(toggled(bool)),
-      this, SLOT(hiddenBoxToggled()));
+  connect(ui.hiddenBox, &QCheckBox::toggled,
+          this, &ConfWidget::hiddenBoxToggled);
 
-  connect(ui.changeKeyButton, SIGNAL(clicked()),
-          this, SLOT(changeKey()));
+  connect(ui.changeKeyButton, &QPushButton::clicked,
+          this, &ConfWidget::changeKey);
 
   myMic = mic;
   if( myMic->isCapturing() ){
-    connect(myMic, SIGNAL(doEvent(double)),
-        this, SLOT(updateAudioSlider(double)));
+    connect(myMic, &Microphone::doEvent,
+            this, &ConfWidget::updateAudioSlider);
     ui.micWidget->setCurrentIndex( 1 );
   }
 
@@ -76,10 +78,10 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd ):
   ui.audioBar->setMinimum( -40.0 );
   ui.audioBar->setMaximum( 1.0 );
 
-  connect( ui.audioSlider, SIGNAL(valueChanged(int)),
-      this, SLOT(setThreshold(int)) );
-  connect( ui.waitSlider, SIGNAL(valueChanged(int)),
-      this, SLOT(setWaitTime(int)) );
+  connect(ui.audioSlider, &QSlider::valueChanged,
+          this, &ConfWidget::setThreshold);
+  connect(ui.waitSlider, &QSlider::valueChanged,
+          this, &ConfWidget::setWaitTime);
 
   waiting = false;
 

--- a/src/confWidget.h
+++ b/src/confWidget.h
@@ -20,7 +20,7 @@
 #ifndef CONFWIDGET_H
 #define CONFWIDGET_H
 
-#include <QtGui/QWidget>
+#include <QtWidgets/QWidget>
 #include <QMainWindow>
 #include <QWidget>
 #include <math.h>

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -17,8 +17,9 @@
  * along with Nadir.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include <QtGui>
-#include <QSound>
+#include <QtWidgets>
+#include <QScreen>
+#include <QGuiApplication>
 #include "mainWidget.h"
 
 MainWidget::MainWidget()
@@ -26,16 +27,16 @@ MainWidget::MainWidget()
   ui.setupUi(this);
   setWindowFlags(Qt::Window);
 
-  connect( ui.confButton, SIGNAL(clicked()),
-      this, SLOT(configure()) );
-  connect( ui.clickButton, SIGNAL(clicked()),
-      this, SLOT(setEvent()) );
-  connect( ui.dbClickButton, SIGNAL(clicked()),
-      this, SLOT(setEvent()) );
-  connect( ui.rightClickButton, SIGNAL(clicked()),
-      this, SLOT(setEvent()) );
-  connect( ui.dragButton, SIGNAL(clicked()),
-      this, SLOT(setEvent()) );
+  connect(ui.confButton, &QPushButton::clicked,
+          this, &MainWidget::configure);
+  connect(ui.clickButton, &QPushButton::clicked,
+          this, &MainWidget::setEvent);
+  connect(ui.dbClickButton, &QPushButton::clicked,
+          this, &MainWidget::setEvent);
+  connect(ui.rightClickButton, &QPushButton::clicked,
+          this, &MainWidget::setEvent);
+  connect(ui.dragButton, &QPushButton::clicked,
+          this, &MainWidget::setEvent);
 
   kbd = new Keyboard();
   if ( !kbd->start() )
@@ -49,11 +50,11 @@ MainWidget::MainWidget()
   trayIcon = NULL;
   firstConf = true;
 
-  hLine = new ScanLine( this, HORIZONTAL, kbd );
-  vLine = new ScanLine( this, VERTICAL, kbd );
+  hLine = new ScanLine( nullptr, HORIZONTAL, kbd );
+  vLine = new ScanLine( nullptr, VERTICAL, kbd );
 
   scanTimer = new QTimer(this);
-  connect(scanTimer, SIGNAL(timeout()), this, SLOT( grabEvent() ));
+  connect(scanTimer, &QTimer::timeout, this, &MainWidget::grabEvent);
 
   QCoreApplication::setOrganizationName( ORGANIZATION_NAME );
   QCoreApplication::setOrganizationDomain( ORGANIZATION_DOMAIN);
@@ -168,9 +169,12 @@ void MainWidget::endWait()
 
 void MainWidget::getScreenSize()
 {
-  QDesktopWidget *desk = QApplication::desktop();
-  setScreenWidth( desk->width() );
-  setScreenHeight( desk->height() );
+  QScreen *screen = QGuiApplication::primaryScreen();
+  if(screen) {
+    QSize size = screen->geometry().size();
+    setScreenWidth(size.width());
+    setScreenHeight(size.height());
+  }
 }
 
 void MainWidget::setScreenWidth( int w )
@@ -405,15 +409,15 @@ void MainWidget::createTrayIcon()
 {
     // Actions
     restoreAction = new QAction(trUtf8("&Restore"), this);
-    connect(restoreAction, SIGNAL(triggered()), this, SLOT(showNormal()));
+    connect(restoreAction, &QAction::triggered, this, &MainWidget::showNormal);
     restoreAction->setIcon(QIcon(":/images/images/nadir.png"));
 
     configAction = new QAction(trUtf8("&Settings"), this);
-    connect(configAction, SIGNAL(triggered()), this, SLOT(configure()));
+    connect(configAction, &QAction::triggered, this, &MainWidget::configure);
     configAction->setIcon(QIcon(":/images/images/menu-configure.png"));
 
     quitAction = new QAction(trUtf8("&Exit"), this);
-    connect(quitAction, SIGNAL(triggered()), this, SLOT(close()));
+    connect(quitAction, &QAction::triggered, this, &MainWidget::close);
     quitAction->setIcon(QIcon(":/images/images/menu-quit.png"));
 
     // Menu
@@ -430,8 +434,8 @@ void MainWidget::createTrayIcon()
     trayIcon->setToolTip(trUtf8("Nadir Multimodal Screen Scanner"));
 
     // Signals
-    connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
-                 this, SLOT(iconActivated(QSystemTrayIcon::ActivationReason)));
+    connect(trayIcon, &QSystemTrayIcon::activated,
+                 this, &MainWidget::iconActivated);
 
     // Show
     trayIcon->show();

--- a/src/scanLine.cpp
+++ b/src/scanLine.cpp
@@ -17,8 +17,9 @@
  * along with Nadir.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-#include <QtGui>
-#include <QDesktopWidget>
+#include <QtWidgets>
+#include <QScreen>
+#include <QGuiApplication>
 #include "mainWidget.h"
 #include "scanLine.h"
 
@@ -29,8 +30,11 @@ ScanLine::ScanLine( QWidget *parent, lineType type, Keyboard *kbd ):
   flags |= Qt::ToolTip;
   flags |= Qt::WindowStaysOnTopHint;
   flags |= Qt::FramelessWindowHint;
+  flags |= Qt::X11BypassWindowManagerHint;
   setWindowFlags( flags );
   setAttribute( Qt::WA_ShowWithoutActivating );
+  setAttribute( Qt::WA_TransparentForMouseEvents );
+  setAttribute( Qt::WA_TranslucentBackground );
   setFocusPolicy( Qt::NoFocus );
 
   QCoreApplication::setOrganizationName( ORGANIZATION_NAME );
@@ -117,9 +121,12 @@ void ScanLine::stopScan( void )
 
 void ScanLine::getScreenSize()
 {
-  QDesktopWidget *desk = QApplication::desktop();
-  setScreenWidth( desk->width() );
-  setScreenHeight( desk->height() );
+  QScreen *screen = QGuiApplication::primaryScreen();
+  if(screen) {
+    QSize size = screen->geometry().size();
+    setScreenWidth(size.width());
+    setScreenHeight(size.height());
+  }
 }
 
 void ScanLine::setScreenWidth( int w )

--- a/src/scanLine.h
+++ b/src/scanLine.h
@@ -21,7 +21,7 @@
 #define SCANLINE_H
 
 #include <QMainWindow>
-#include <QtGui/QWidget>
+#include <QtWidgets/QWidget>
 #include <QTimer>
 #include <QWidget>
 #include <X11/Xlib.h>


### PR DESCRIPTION
## Summary
- update Qt5 build rules and require C++11
- refactor Qt connections to modern syntax
- use QScreen for screen size detection
- ensure scan lines are always visible
- document Qt5 in README

## Testing
- `cmake ..` *(fails: could not find Qt5)*
- `make` *(fails: no makefile generated)*

------
https://chatgpt.com/codex/tasks/task_e_6887add7a598832e9a6bf1a30d4db6b3