### PR TITLE
Fix window manager modifiers with click release

### DIFF
--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -302,14 +302,28 @@ void Keyboard::key( int k )
   XTestFakeKeyEvent( disp, k, False, KEY_PRESS_TIME );
 }
 
+void Keyboard::releasePressedKeys()
+{
+  if (!disp)
+    return;
+  char pressed[32];
+  XQueryKeymap(disp, pressed);
+  for (int idx = 0; idx < 32 * 8; ++idx) {
+    if (bit(pressed, idx))
+      XTestFakeKeyEvent(disp, idx, False, 0);
+  }
+}
+
 void Keyboard::click(void)
 {
+  releasePressedKeys();
   XTestFakeButtonEvent( disp, 1, True, 0 );
   XTestFakeButtonEvent( disp, 1, False, KEY_PRESS_TIME );
 }
 
 void Keyboard::doubleClick(void)
 {
+  releasePressedKeys();
   XTestFakeButtonEvent( disp, 1, True, KEY_PRESS_TIME2 );
   XTestFakeButtonEvent( disp, 1, False, KEY_PRESS_TIME2 );
   XTestFakeButtonEvent( disp, 1, True, KEY_PRESS_TIME2 );
@@ -318,17 +332,20 @@ void Keyboard::doubleClick(void)
 
 void Keyboard::rightClick(void)
 {
+  releasePressedKeys();
   XTestFakeButtonEvent( disp, 3, True, 0 );
   XTestFakeButtonEvent( disp, 3, False, KEY_PRESS_TIME );
 }
 
 void Keyboard::drag(void)
 {
+  releasePressedKeys();
   XTestFakeButtonEvent( disp, 1, True, 0 );
 }
 
 void Keyboard::drop(void)
 {
+  releasePressedKeys();
   XTestFakeButtonEvent( disp, 1, False, KEY_PRESS_TIME );
 }
 

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -73,6 +73,8 @@ class Keyboard
     void loadKeyCode();
     void setKeyCode(int i);
     Display *getDisplay();
+    /// Release all currently pressed keys
+    void releasePressedKeys();
 
     int StrToChar(char *data);
     const char *KeyCodeToStr(int code, int down, int mod);


### PR DESCRIPTION
## Summary
- add helper to release pressed keys before sending click events
- call the helper from all mouse event methods

## Testing
- `cmake ..` *(fails: Could not find Qt5)*

------
https://chatgpt.com/codex/tasks/task_e_688a78bed448832ea25a5bbc6662c54c