### PR TITLE
Allow microphone preview in settings

### DIFF
--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -116,11 +116,11 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
   });
 
   myMic = mic;
-  if( myMic->isCapturing() ){
-    connect(myMic, &Microphone::doEvent,
-            this, &ConfWidget::updateAudioSlider);
+  startedMicCapture = false;
+  connect(myMic, &Microphone::doEvent,
+          this, &ConfWidget::updateAudioSlider);
+  if( myMic->isCapturing() )
     ui.micWidget->setCurrentIndex( 1 );
-  }
 
   myKbd = kbd;
   myMouse = mouse;
@@ -151,6 +151,12 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
 
   // Shrink window to minimum needed size
   resize(0,0);
+}
+
+ConfWidget::~ConfWidget()
+{
+  if(startedMicCapture && myMic)
+      myMic->capture(false);
 }
 
 void ConfWidget::minimizedBoxToggled()
@@ -373,10 +379,19 @@ void ConfWidget::changeButton()
 
 void ConfWidget::scanModeChanged()
 {
-  if (ui.micMode->isChecked())
+  if (ui.micMode->isChecked()) {
     ui.micWidget->setCurrentIndex(1);
-  else
+    if(!myMic->isCapturing()) {
+        myMic->capture(true);
+        startedMicCapture = true;
+    }
+  } else {
     ui.micWidget->setCurrentIndex(0);
+    if(startedMicCapture) {
+        myMic->capture(false);
+        startedMicCapture = false;
+    }
+  }
 }
 
 void ConfWidget::keyPressEvent(QKeyEvent *e)

--- a/src/confWidget.h
+++ b/src/confWidget.h
@@ -38,6 +38,7 @@ class ConfWidget : public QWidget
 
   public:
     ConfWidget( QWidget *parent = 0, Microphone *mic = 0, Keyboard *kbd = 0, Mouse *mouse = 0 );
+    ~ConfWidget();
     void loadSettings();
     void closeEvent();
     QString backgroundColor();
@@ -75,6 +76,7 @@ class ConfWidget : public QWidget
     int threshold;
     unsigned int waitTime;
     bool waiting;
+    bool startedMicCapture;
     int mouseButton;
     int originalMouseButton;
     int mouseButtonCount;


### PR DESCRIPTION
## Summary
- let ConfWidget start and stop microphone capture when toggling scan mode
- stop temporary capture when configuration closes

## Testing
- `cmake ..` *(fails: Qt5 not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a8488c6b8832ea6653a641ad7f934