### PR TITLE
Fix premature microphone scan on config change

### DIFF
--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -117,6 +117,7 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
   });
 
   myMic = mic;
+  startedMicCapture = false;
   mainWidget = qobject_cast<MainWidget*>(parent);
   if(mainWidget)
       QObject::disconnect(myMic, SIGNAL(doEvent(double)),
@@ -158,7 +159,11 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
 }
 
 
-ConfWidget::~ConfWidget() {}
+ConfWidget::~ConfWidget()
+{
+  if(startedMicCapture && myMic)
+      myMic->capture(false);
+}
 
 void ConfWidget::minimizedBoxToggled()
 {
@@ -366,6 +371,11 @@ void ConfWidget::closeEvent()
       QObject::connect(myMic, SIGNAL(doEvent(double)),
                        mainWidget, SLOT(micEvent(double)));
 
+  if(startedMicCapture && myMic){
+      myMic->capture(false);
+      startedMicCapture = false;
+  }
+
   if(myMouse)
       myMouse->setButtonCode(originalMouseButton);
 }
@@ -390,8 +400,16 @@ void ConfWidget::scanModeChanged()
 {
   if (ui.micMode->isChecked()) {
     ui.micWidget->setCurrentIndex(1);
+    if(!myMic->isCapturing()) {
+        myMic->capture(true);
+        startedMicCapture = true;
+    }
   } else {
     ui.micWidget->setCurrentIndex(0);
+    if(startedMicCapture) {
+        myMic->capture(false);
+        startedMicCapture = false;
+    }
   }
 }
 

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -117,6 +117,10 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
   });
 
   myMic = mic;
+  mainWidget = qobject_cast<MainWidget*>(parent);
+  if(mainWidget)
+      disconnect(myMic, &Microphone::doEvent,
+                 mainWidget, &MainWidget::micEvent);
   startedMicCapture = false;
   connect(myMic, &Microphone::doEvent,
           this, &ConfWidget::updateAudioSlider);
@@ -362,6 +366,10 @@ void ConfWidget::closeEvent()
       myMic->capture(false);
       startedMicCapture = false;
   }
+
+  if(mainWidget)
+      connect(myMic, &Microphone::doEvent,
+              mainWidget, &MainWidget::micEvent);
 
   if(myMouse)
       myMouse->setButtonCode(originalMouseButton);

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -117,7 +117,7 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
   });
 
   myMic = mic;
-  startedMicCapture = false;
+  // microphone preview disabled when configuring
   mainWidget = qobject_cast<MainWidget*>(parent);
   if(mainWidget)
       QObject::disconnect(myMic, SIGNAL(doEvent(double)),
@@ -159,11 +159,7 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
 }
 
 
-ConfWidget::~ConfWidget()
-{
-  if(startedMicCapture && myMic)
-      myMic->capture(false);
-}
+
 
 void ConfWidget::minimizedBoxToggled()
 {
@@ -371,11 +367,7 @@ void ConfWidget::closeEvent()
       QObject::connect(myMic, SIGNAL(doEvent(double)),
                        mainWidget, SLOT(micEvent(double)));
 
-  if(startedMicCapture && myMic){
-      if(!ui.micMode->isChecked())
-          myMic->capture(false);
-      startedMicCapture = false;
-  }
+  // preview capture is disabled, no need to stop here
 
   if(myMouse)
       myMouse->setButtonCode(originalMouseButton);
@@ -401,16 +393,8 @@ void ConfWidget::scanModeChanged()
 {
   if (ui.micMode->isChecked()) {
     ui.micWidget->setCurrentIndex(1);
-    if(!myMic->isCapturing()) {
-        myMic->capture(true);
-        startedMicCapture = true;
-    }
   } else {
     ui.micWidget->setCurrentIndex(0);
-    if(startedMicCapture) {
-        myMic->capture(false);
-        startedMicCapture = false;
-    }
   }
 }
 

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -291,6 +291,12 @@ void ConfWidget::save()
       myMouse->setButtonCode(mouseButton);
   originalMouseButton = mouseButton;
 
+  bool micModeSelected = ui.micMode->isChecked();
+  if(startedMicCapture && myMic && !micModeSelected){
+      myMic->capture(false);
+  }
+  startedMicCapture = false;
+
   emit closing();
   close();
 }

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -119,8 +119,8 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
   myMic = mic;
   mainWidget = qobject_cast<MainWidget*>(parent);
   if(mainWidget)
-      disconnect(myMic, &Microphone::doEvent,
-                 mainWidget, &MainWidget::micEvent);
+      QObject::disconnect(myMic, SIGNAL(doEvent(double)),
+                          mainWidget, SLOT(micEvent(double)));
   startedMicCapture = false;
   connect(myMic, &Microphone::doEvent,
           this, &ConfWidget::updateAudioSlider);
@@ -368,8 +368,8 @@ void ConfWidget::closeEvent()
   }
 
   if(mainWidget)
-      connect(myMic, &Microphone::doEvent,
-              mainWidget, &MainWidget::micEvent);
+      QObject::connect(myMic, SIGNAL(doEvent(double)),
+                       mainWidget, SLOT(micEvent(double)));
 
   if(myMouse)
       myMouse->setButtonCode(originalMouseButton);

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -372,7 +372,8 @@ void ConfWidget::closeEvent()
                        mainWidget, SLOT(micEvent(double)));
 
   if(startedMicCapture && myMic){
-      myMic->capture(false);
+      if(!ui.micMode->isChecked())
+          myMic->capture(false);
       startedMicCapture = false;
   }
 

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -121,7 +121,6 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
   if(mainWidget)
       QObject::disconnect(myMic, SIGNAL(doEvent(double)),
                           mainWidget, SLOT(micEvent(double)));
-  startedMicCapture = false;
   connect(myMic, &Microphone::doEvent,
           this, &ConfWidget::updateAudioSlider);
   if( myMic->isCapturing() )
@@ -158,11 +157,8 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
   resize(0,0);
 }
 
-ConfWidget::~ConfWidget()
-{
-  if(startedMicCapture && myMic)
-      myMic->capture(false);
-}
+
+ConfWidget::~ConfWidget() {}
 
 void ConfWidget::minimizedBoxToggled()
 {
@@ -291,11 +287,7 @@ void ConfWidget::save()
       myMouse->setButtonCode(mouseButton);
   originalMouseButton = mouseButton;
 
-  bool micModeSelected = ui.micMode->isChecked();
-  if(startedMicCapture && myMic && !micModeSelected){
-      myMic->capture(false);
-  }
-  startedMicCapture = false;
+
 
   emit closing();
   close();
@@ -368,10 +360,7 @@ void ConfWidget::closeEvent()
   settings.setValue( "pos", pos() );
   settings.endGroup();
 
-  if(startedMicCapture && myMic){
-      myMic->capture(false);
-      startedMicCapture = false;
-  }
+
 
   if(mainWidget)
       QObject::connect(myMic, SIGNAL(doEvent(double)),
@@ -401,16 +390,8 @@ void ConfWidget::scanModeChanged()
 {
   if (ui.micMode->isChecked()) {
     ui.micWidget->setCurrentIndex(1);
-    if(!myMic->isCapturing()) {
-        myMic->capture(true);
-        startedMicCapture = true;
-    }
   } else {
     ui.micWidget->setCurrentIndex(0);
-    if(startedMicCapture) {
-        myMic->capture(false);
-        startedMicCapture = false;
-    }
   }
 }
 

--- a/src/confWidget.h
+++ b/src/confWidget.h
@@ -32,6 +32,8 @@
 #include "microphone.h"
 #include "ui_confWidget.h"
 
+class MainWidget;
+
 class ConfWidget : public QWidget
 {
   Q_OBJECT
@@ -73,6 +75,7 @@ class ConfWidget : public QWidget
     Microphone *myMic;
     Keyboard *myKbd;
     Mouse *myMouse;
+    MainWidget *mainWidget;
     int threshold;
     unsigned int waitTime;
     bool waiting;

--- a/src/confWidget.h
+++ b/src/confWidget.h
@@ -79,6 +79,7 @@ class ConfWidget : public QWidget
     int threshold;
     unsigned int waitTime;
     bool waiting;
+    bool startedMicCapture;
     int mouseButton;
     int originalMouseButton;
     int mouseButtonCount;

--- a/src/confWidget.h
+++ b/src/confWidget.h
@@ -40,7 +40,6 @@ class ConfWidget : public QWidget
 
   public:
     ConfWidget( QWidget *parent = 0, Microphone *mic = 0, Keyboard *kbd = 0, Mouse *mouse = 0 );
-    ~ConfWidget();
     void loadSettings();
     void closeEvent();
     QString backgroundColor();
@@ -79,7 +78,6 @@ class ConfWidget : public QWidget
     int threshold;
     unsigned int waitTime;
     bool waiting;
-    bool startedMicCapture;
     int mouseButton;
     int originalMouseButton;
     int mouseButtonCount;

--- a/src/confWidget.h
+++ b/src/confWidget.h
@@ -79,7 +79,6 @@ class ConfWidget : public QWidget
     int threshold;
     unsigned int waitTime;
     bool waiting;
-    bool startedMicCapture;
     int mouseButton;
     int originalMouseButton;
     int mouseButtonCount;

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -255,6 +255,7 @@ void MainWidget::stop()
 
 void MainWidget::configure( void )
 {
+  stop();
   confWidget = new ConfWidget( this, mic, kbd, mouse );
   confWidget->show();
 }

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -118,13 +118,16 @@ void MainWidget::loadSettings()
 void MainWidget::reloadSettings()
 {
   Mode oldMode = mode;
+  bool wasCapturing = mic->isCapturing();
   loadSettings();
 
   // Any case but continuing in mic mode
   if( !( oldMode == mode && mode == MIC ) ){
     stop();
     scan();
-  };
+  } else if( !wasCapturing ) {
+    scan();
+  }
 
   // From mic mode to other modes
   if( oldMode != mode && mode != MIC ){

--- a/src/microphone.cpp
+++ b/src/microphone.cpp
@@ -140,6 +140,8 @@ void Microphone::capture(bool on)
         capturing = false;
         if (!jackMode) {
             alsaCapture->stop();
+            if(alsaCapture->isRunning())
+                alsaCapture->wait();
         }
         ringBuffer->reset();
         for (l1 = 0; l1 < meters.size(); l1++) {


### PR DESCRIPTION
## Summary
- prevent microphone events from reaching main widget before saving settings

## Testing
- `cmake ..` *(fails: Qt5 not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b7d66bac4832e8d24969c7beb2d0b