### PR TITLE
Fix mouse grab after opening configuration

### DIFF
--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -118,6 +118,7 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
 
   myMic = mic;
   previewCaptureStarted = false;
+  originalMode = 0;
   connect(myMic, &Microphone::doEvent,
           this, &ConfWidget::updateAudioSlider);
 
@@ -199,6 +200,7 @@ void ConfWidget::loadSettings()
   ui.keyMode->setChecked(modeVal == 0);
   ui.micMode->setChecked(modeVal == 1);
   ui.mouseMode->setChecked(modeVal == 2);
+  originalMode = modeVal;
   lineColor = settings.value( "color", "255,0,0" ).toString();
   updateColorButton();
   setThreshold( settings.value( "audioThreshold", 0 ).toInt() );
@@ -262,6 +264,7 @@ void ConfWidget::save()
   else
     i = 2;
   settings.setValue( "mode", i );
+  originalMode = i; // update for closeEvent
   i = ( ui.simpleClickBox->isChecked() ) ? 0 : 1;
   settings.setValue( "click", i );
   i = ( ui.hidePointerBox->isChecked() ) ? 1 : 0;
@@ -378,7 +381,7 @@ void ConfWidget::closeEvent()
   }
 
   if(myMouse){
-      if(ui.mouseMode->isChecked())
+      if(originalMode == 2)
           myMouse->setButtonCode(originalMouseButton);
       else
           myMouse->setButtonCode(0);
@@ -403,6 +406,13 @@ void ConfWidget::changeButton()
 
 void ConfWidget::scanModeChanged()
 {
+  if(myMouse){
+      if(ui.mouseMode->isChecked())
+          myMouse->setButtonCode(mouseButton);
+      else
+          myMouse->setButtonCode(0);
+  }
+
   // Microphone settings remain visible regardless of the selected mode.
   // Capture will start after saving if microphone mode is chosen.
 }

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -136,10 +136,6 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
   myMouse = mouse;
   mouseButtonCount = myMouse ? myMouse->getButtonCount() : 0;
 
-  QCoreApplication::setOrganizationName( ORGANIZATION_NAME );
-  QCoreApplication::setOrganizationDomain( ORGANIZATION_DOMAIN);
-  QCoreApplication::setApplicationName( APPLICATION_NAME );
-
   loadSettings();
 
   // If the current scan mode is not mouse-based, make sure no button
@@ -214,7 +210,6 @@ void ConfWidget::loadSettings()
   setThreshold( settings.value( "audioThreshold", 0 ).toInt() );
   ui.audioBar->setValue( threshold );
   setWaitTime( settings.value( "waitTime", 1000 ).toInt() );
-  ui.audioBar->setValue( threshold );
   ui.keyCodeField->setText( settings.value( "keycode", 65).toString() );
   ui.keySymField->setText( settings.value( "keysym", "ESPACIO").toString() );
   ui.mouseButtonField->setText(mouseButtonName(mouseButton));
@@ -414,12 +409,8 @@ void ConfWidget::changeButton()
 
 void ConfWidget::scanModeChanged()
 {
-  if(myMouse){
-      if(ui.mouseMode->isChecked())
-          myMouse->setButtonCode(mouseButton);
-      else
-          myMouse->setButtonCode(0);
-  }
+  if(myMouse)
+      myMouse->setButtonCode(ui.mouseMode->isChecked() ? mouseButton : 0);
 
   // Microphone settings remain visible regardless of the selected mode.
   // Capture will start after saving if microphone mode is chosen.

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -197,6 +197,8 @@ void ConfWidget::loadSettings()
   ui.doubleClickBox->setChecked( settings.value( "click", 0 ).toBool() );
   ui.hidePointerBox->setChecked( settings.value( "hide", 0 ).toBool() );
   int modeVal = settings.value("mode", 0).toInt();
+  mouseButton = settings.value("mouseButton", 1).toInt();
+  originalMouseButton = mouseButton;
   ui.keyMode->setChecked(modeVal == 0);
   ui.micMode->setChecked(modeVal == 1);
   ui.mouseMode->setChecked(modeVal == 2);
@@ -209,8 +211,6 @@ void ConfWidget::loadSettings()
   ui.audioBar->setValue( threshold );
   ui.keyCodeField->setText( settings.value( "keycode", 65).toString() );
   ui.keySymField->setText( settings.value( "keysym", "ESPACIO").toString() );
-  mouseButton = settings.value("mouseButton", 1).toInt();
-  originalMouseButton = mouseButton;
   ui.mouseButtonField->setText(mouseButtonName(mouseButton));
   ui.confirmOnExitBox->setChecked( settings.value( "confirmOnExit", 1).toBool() );
   settings.endGroup();

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -372,7 +372,7 @@ void ConfWidget::showAboutText()
   ui.tabWidget->setCurrentWidget(ui.aboutTab);
 }
 
-void ConfWidget::closeEvent()
+void ConfWidget::closeEvent(QCloseEvent *e)
 {
   QSettings settings;
 
@@ -392,6 +392,8 @@ void ConfWidget::closeEvent()
       else
           myMouse->setButtonCode(0);
   }
+
+  QWidget::closeEvent(e);
 }
 
 void ConfWidget::changeKey()

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -291,8 +291,12 @@ void ConfWidget::save()
   settings.sync();
 
   myKbd->setKeyCode(ui.keyCodeField->text().toInt());
-  if(myMouse)
-      myMouse->setButtonCode(mouseButton);
+  if(myMouse){
+      if(ui.mouseMode->isChecked())
+          myMouse->setButtonCode(mouseButton);
+      else
+          myMouse->setButtonCode(0);
+  }
   originalMouseButton = mouseButton;
 
   emit closing();
@@ -373,8 +377,12 @@ void ConfWidget::closeEvent()
       previewCaptureStarted = false;
   }
 
-  if(myMouse)
-      myMouse->setButtonCode(originalMouseButton);
+  if(myMouse){
+      if(ui.mouseMode->isChecked())
+          myMouse->setButtonCode(originalMouseButton);
+      else
+          myMouse->setButtonCode(0);
+  }
 }
 
 void ConfWidget::changeKey()

--- a/src/confWidget.cpp
+++ b/src/confWidget.cpp
@@ -142,6 +142,12 @@ ConfWidget::ConfWidget( QWidget *parent, Microphone *mic, Keyboard *kbd, Mouse *
 
   loadSettings();
 
+  // If the current scan mode is not mouse-based, make sure no button
+  // remains grabbed while the settings window is open. This avoids
+  // blocking the configured mouse button in the rest of the system.
+  if(myMouse && !ui.mouseMode->isChecked())
+      myMouse->setButtonCode(0);
+
   ui.audioSlider->setMinimum( -40.0 );
   ui.audioSlider->setMaximum( 1.0 );
   ui.audioSlider->setValue( threshold );

--- a/src/confWidget.h
+++ b/src/confWidget.h
@@ -40,7 +40,7 @@ class ConfWidget : public QWidget
     ConfWidget( QWidget *parent = 0, Microphone *mic = 0, Keyboard *kbd = 0, Mouse *mouse = 0 );
     ~ConfWidget();
     void loadSettings();
-    void closeEvent();
+    void closeEvent(QCloseEvent *e) override;
     QString backgroundColor();
     void updateColorButton();
 

--- a/src/confWidget.h
+++ b/src/confWidget.h
@@ -77,6 +77,7 @@ class ConfWidget : public QWidget
     unsigned int waitTime;
     bool waiting;
     bool previewCaptureStarted;
+    int originalMode; // scan mode when dialog opened
     int mouseButton;
     int originalMouseButton;
     int mouseButtonCount;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,10 @@ int main(int argc, char *argv[])
 {
   QApplication app(argc, argv);
 
+  QCoreApplication::setOrganizationName( ORGANIZATION_NAME );
+  QCoreApplication::setOrganizationDomain( ORGANIZATION_DOMAIN );
+  QCoreApplication::setApplicationName( APPLICATION_NAME );
+
   // Internationalitation
   QTranslator translator;
 
@@ -53,10 +57,6 @@ int main(int argc, char *argv[])
 
   MainWidget win;
   QSettings settings;
-
-  QCoreApplication::setOrganizationName( ORGANIZATION_NAME );
-  QCoreApplication::setOrganizationDomain( ORGANIZATION_DOMAIN);
-  QCoreApplication::setApplicationName( APPLICATION_NAME );
   
   settings.beginGroup( "mainWidget" );
   bool min = settings.value( "minimized", false ).toBool();

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -349,6 +349,7 @@ void MainWidget::doEvent()
   int oldButton = 0;
   if(mode == MOUSE && mouse){
       oldButton = mouse->getButtonCode();
+      mouse->waitForRelease();
       mouse->setButtonCode(0); // allow fake clicks to propagate
   }
 

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -293,9 +293,19 @@ void MainWidget::changeState()
       vLine->hide();
       kbd->move( vLine->getX(), hLine->getY() );
       doEvent();
-      state = (mouseEvent == DROP) ? SCAN1 : ((continuous) ? SCAN1 : STOP);
-      kbd->snoop();
-      changeState();
+      if (mouseEvent == DROP) {
+        // After initiating a drag the mouse button remains pressed. Keep the
+        // scan stopped so the user can manually restart it to choose the drop
+        // location.
+        state = SCAN1;
+        kbd->snoop();
+        // Do not call changeState(), leaving the system idle until the user
+        // triggers the next scan cycle.
+      } else {
+        state = (continuous) ? SCAN1 : STOP;
+        kbd->snoop();
+        changeState();
+      }
       break;
   };
 }

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -20,6 +20,7 @@
 #include <QtWidgets>
 #include <QScreen>
 #include <QGuiApplication>
+#include <QCursor>
 #include "mainWidget.h"
 
 MainWidget::MainWidget()
@@ -341,6 +342,19 @@ void MainWidget::doEvent()
   if(mode == MOUSE && mouse){
       oldButton = mouse->getButtonCode();
       mouse->setButtonCode(0); // allow fake clicks to propagate
+  }
+
+  // If the pointer is over Nadir's control panel, this click is meant to
+  // activate one of the UI buttons rather than execute the currently
+  // selected action. Just send a normal left click so the button receives
+  // the event and skip the action logic.
+  QPoint globalPos = QCursor::pos();
+  if(rect().contains(mapFromGlobal(globalPos))){
+      kbd->click();
+      kbd->flush();
+      if(mode == MOUSE && mouse)
+          mouse->setButtonCode(oldButton);
+      return;
   }
 
   switch( mouseEvent ){

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -104,9 +104,15 @@ void MainWidget::loadSettings()
   setThreshold( settings.value( "audioThreshold", 0 ).toInt() );
   waitTime = settings.value( "waitTime", 1000 ).toInt();
   confirmOnExit = settings.value( "confirmOnExit", 1).toBool();
+  int loadedMouseButton = settings.value("mouseButton", 1).toInt();
   settings.endGroup();
 
   getScreenSize();
+
+  if(mode == MOUSE)
+      mouse->setButtonCode(loadedMouseButton);
+  else
+      mouse->setButtonCode(0);
 
   kbd->setEscapeCode( escapeCode );
   hLine->loadSettings();

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -60,10 +60,6 @@ MainWidget::MainWidget()
   scanTimer = new QTimer(this);
   connect(scanTimer, &QTimer::timeout, this, &MainWidget::grabEvent);
 
-  QCoreApplication::setOrganizationName( ORGANIZATION_NAME );
-  QCoreApplication::setOrganizationDomain( ORGANIZATION_DOMAIN);
-  QCoreApplication::setApplicationName( APPLICATION_NAME );
-
   loadInitialSettings();
   loadSettings();
   if(showTrayIcon)
@@ -239,13 +235,13 @@ void MainWidget::scan()
 
 void MainWidget::grabEvent()
 {
-  unsigned int e = 0;
+  bool pressed = false;
   if(mode == KEY)
-      e = kbd->grabKeyEvent();
+      pressed = kbd->grabKeyEvent();
   else if(mode == MOUSE)
-      e = mouse->grabButtonEvent();
+      pressed = mouse->grabButtonEvent();
 
-  if(e)
+  if(pressed)
       changeState();
 }
 

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -390,11 +390,15 @@ void MainWidget::doEvent()
 
     case DRAG:
       kbd->drag();
+      if(mode == MOUSE && mouse)
+          mouse->ungrabPointer();
       mouseEvent = DROP;
       break;
 
     case DROP:
       kbd->drop();
+      if(mode == MOUSE && mouse)
+          mouse->ungrabPointer();
       mouseEvent = defaultEvent;
       checkDefaultEventButton();
       break;

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -337,6 +337,12 @@ void MainWidget::setDefaultEvent( int i )
 
 void MainWidget::doEvent()
 {
+  int oldButton = 0;
+  if(mode == MOUSE && mouse){
+      oldButton = mouse->getButtonCode();
+      mouse->setButtonCode(0); // allow fake clicks to propagate
+  }
+
   switch( mouseEvent ){
     case LEFT:
       kbd->click();
@@ -365,6 +371,9 @@ void MainWidget::doEvent()
   };
 
   kbd->flush();
+
+  if(mode == MOUSE && mouse)
+      mouse->setButtonCode(oldButton);
 
   if( hidePointer )
     kbd->move( getScreenWidth(), getScreenHeight() );

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -21,6 +21,8 @@
 #include <QScreen>
 #include <QGuiApplication>
 #include <QCursor>
+#include <QApplication>
+#include <QPushButton>
 #include "mainWidget.h"
 
 MainWidget::MainWidget()
@@ -346,11 +348,18 @@ void MainWidget::doEvent()
 
   // If the pointer is over Nadir's control panel, this click is meant to
   // activate one of the UI buttons rather than execute the currently
-  // selected action. Just send a normal left click so the button receives
-  // the event and skip the action logic.
+  // selected action. Simulate a normal button click using Qt's API so
+  // autoExclusive buttons update correctly.
   QPoint globalPos = QCursor::pos();
   if(rect().contains(mapFromGlobal(globalPos))){
-      kbd->click();
+      if(QWidget *w = QApplication::widgetAt(globalPos)){
+          if(auto *btn = qobject_cast<QPushButton*>(w))
+              btn->click();
+          else
+              kbd->click();
+      } else {
+          kbd->click();
+      }
       kbd->flush();
       if(mode == MOUSE && mouse)
           mouse->setButtonCode(oldButton);

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -293,7 +293,7 @@ void MainWidget::changeState()
       vLine->hide();
       kbd->move( vLine->getX(), hLine->getY() );
       doEvent();
-      state = (continuous) ? SCAN1 : STOP;
+      state = (mouseEvent == DROP) ? SCAN1 : ((continuous) ? SCAN1 : STOP);
       kbd->snoop();
       changeState();
       break;

--- a/src/mainWidget.cpp
+++ b/src/mainWidget.cpp
@@ -395,16 +395,25 @@ void MainWidget::doEvent()
 
 void MainWidget::checkDefaultEventButton()
 {
-  switch( defaultEvent ){
+  // Manually clear all check marks before setting the one
+  // corresponding to the default event. The automatic exclusivity of
+  // the buttons only applies when they are clicked by the user, not
+  // when their state is changed programmatically.
+  ui.clickButton->setChecked(false);
+  ui.dbClickButton->setChecked(false);
+  ui.rightClickButton->setChecked(false);
+  ui.dragButton->setChecked(false);
+
+  switch (defaultEvent) {
     case LEFT:
-      ui.clickButton->setChecked( true );
+      ui.clickButton->setChecked(true);
       break;
     case DOUBLE:
-      ui.dbClickButton->setChecked( true );
+      ui.dbClickButton->setChecked(true);
       break;
     default:
       break;
-  };
+  }
 }
 
 void MainWidget::closeEvent(QCloseEvent *e)

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -81,6 +81,14 @@ void Mouse::ungrabButton()
     }
 }
 
+void Mouse::ungrabPointer()
+{
+    if(display){
+        XUngrabPointer(display, CurrentTime);
+        XSync(display, False);
+    }
+}
+
 void Mouse::waitForRelease()
 {
     if(!display || buttonCode <= 0)

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -33,7 +33,7 @@ bool Mouse::start()
                     ButtonPressMask, GrabModeAsync, GrabModeAsync,
                     None, None);
         grabbed = true;
-        XFlush(display);
+        XSync(display, False);
     }
     return true;
 }
@@ -46,7 +46,7 @@ void Mouse::stop()
         // Release any active pointer grab so synthetic events reach
         // the target window even if the physical button is still pressed
         XUngrabPointer(display, CurrentTime);
-        XFlush(display);
+        XSync(display, False);
     }
     if(display)
         XCloseDisplay(display);
@@ -70,7 +70,7 @@ void Mouse::setButtonCode(int i)
         XUngrabButton(display, buttonCode, AnyModifier,
                       DefaultRootWindow(display));
         XUngrabPointer(display, CurrentTime);
-        XFlush(display);
+        XSync(display, False);
         grabbed = false;
     }
     buttonCode = i;
@@ -79,7 +79,7 @@ void Mouse::setButtonCode(int i)
                     DefaultRootWindow(display), False,
                     ButtonPressMask, GrabModeAsync, GrabModeAsync,
                     None, None);
-        XFlush(display);
+        XSync(display, False);
         grabbed = true;
     }
 }

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -41,7 +41,11 @@ bool Mouse::start()
 void Mouse::stop()
 {
     if(grabbed && buttonCode > 0){
-        XUngrabButton(display, buttonCode, AnyModifier, DefaultRootWindow(display));
+        XUngrabButton(display, buttonCode, AnyModifier,
+                      DefaultRootWindow(display));
+        // Release any active pointer grab so synthetic events reach
+        // the target window even if the physical button is still pressed
+        XUngrabPointer(display, CurrentTime);
         XFlush(display);
     }
     if(display)
@@ -63,7 +67,9 @@ unsigned int Mouse::grabButtonEvent()
 void Mouse::setButtonCode(int i)
 {
     if(grabbed && buttonCode > 0 && display){
-        XUngrabButton(display, buttonCode, AnyModifier, DefaultRootWindow(display));
+        XUngrabButton(display, buttonCode, AnyModifier,
+                      DefaultRootWindow(display));
+        XUngrabPointer(display, CurrentTime);
         XFlush(display);
         grabbed = false;
     }

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -33,14 +33,17 @@ bool Mouse::start()
                     ButtonPressMask, GrabModeAsync, GrabModeAsync,
                     None, None);
         grabbed = true;
+        XFlush(display);
     }
     return true;
 }
 
 void Mouse::stop()
 {
-    if(grabbed && buttonCode > 0)
+    if(grabbed && buttonCode > 0){
         XUngrabButton(display, buttonCode, AnyModifier, DefaultRootWindow(display));
+        XFlush(display);
+    }
     if(display)
         XCloseDisplay(display);
 }
@@ -61,6 +64,7 @@ void Mouse::setButtonCode(int i)
 {
     if(grabbed && buttonCode > 0 && display){
         XUngrabButton(display, buttonCode, AnyModifier, DefaultRootWindow(display));
+        XFlush(display);
         grabbed = false;
     }
     buttonCode = i;
@@ -69,6 +73,7 @@ void Mouse::setButtonCode(int i)
                     DefaultRootWindow(display), False,
                     ButtonPressMask, GrabModeAsync, GrabModeAsync,
                     None, None);
+        XFlush(display);
         grabbed = true;
     }
 }

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -27,14 +27,8 @@ bool Mouse::start()
         return false;
     screenNumber = DefaultScreen(display);
     grabbed = false;
-    if(buttonCode > 0){
-        XGrabButton(display, buttonCode, AnyModifier,
-                    DefaultRootWindow(display), False,
-                    ButtonPressMask, GrabModeAsync, GrabModeAsync,
-                    None, None);
-        grabbed = true;
-        XSync(display, False);
-    }
+    // Button grabs are now performed explicitly via setButtonCode()
+    // once the application knows which scan mode is active.
     return true;
 }
 

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -26,6 +26,8 @@ public:
     void setButtonCode(int i);
     // Read the button from persistent settings
     void loadButtonCode();
+    // Currently active button number
+    int getButtonCode() const { return buttonCode; }
     // Returns the number of available mouse buttons
     int getButtonCount() const;
 

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -29,6 +29,8 @@ public:
     int getButtonCode() const { return buttonCode; }
     // Returns the number of available mouse buttons
     int getButtonCount() const;
+    // Wait until the watched button is released
+    void waitForRelease();
 
 private:
     Display *display;      // connection to the X server

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -33,7 +33,6 @@ public:
     void waitForRelease();
     // Release any active pointer grab without altering the button grab
     void ungrabPointer();
-
 private:
     Display *display;      // connection to the X server
     int screenNumber;      // default screen index
@@ -43,6 +42,11 @@ private:
 
     void ungrabButton();   // helper to release current grab
     unsigned int buttonMask() const; // mask for XQueryPointer
+    // Process pending X events and update button state; returns true if a new
+    // press was detected
+    bool processButtonEvents();
+    // Query the current physical state of the watched button
+    bool isButtonDown() const;
 };
 
 #endif // MOUSE_H

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -35,8 +35,10 @@ private:
     int screenNumber;      // default screen index
     bool grabbed;          // whether the button is currently grabbed
     int buttonCode;        // X11 button number to watch
+    bool lastDown;         // last known state of the watched button
 
     void ungrabButton();   // helper to release current grab
+    unsigned int buttonMask() const; // mask for XQueryPointer
 };
 
 #endif // MOUSE_H

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -4,7 +4,6 @@
 #include <X11/extensions/XTest.h>
 #include <X11/Xlib.h>
 #include "fixx11h.h"
-#include <QCoreApplication>
 #include <QSettings>
 #include "common.h"
 
@@ -15,13 +14,13 @@ public:
     Mouse();
     ~Mouse();
 
-    // Open the X11 display and grab the configured button
+    // Open the X11 display
     bool start();
     // Release the grab and close the display
     void stop();
 
     // Check for a press of the selected button
-    unsigned int grabButtonEvent();
+    bool grabButtonEvent();
     // Change the button number while running
     void setButtonCode(int i);
     // Read the button from persistent settings
@@ -36,6 +35,8 @@ private:
     int screenNumber;      // default screen index
     bool grabbed;          // whether the button is currently grabbed
     int buttonCode;        // X11 button number to watch
+
+    void ungrabButton();   // helper to release current grab
 };
 
 #endif // MOUSE_H

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -31,6 +31,8 @@ public:
     int getButtonCount() const;
     // Wait until the watched button is released
     void waitForRelease();
+    // Release any active pointer grab without altering the button grab
+    void ungrabPointer();
 
 private:
     Display *display;      // connection to the X server


### PR DESCRIPTION
## Summary
- set QSettings parameters before instantiating `MainWidget`

This ensures the mouse button is loaded from the correct config on startup and prevents grabbing it only after opening the settings window.

## Testing
- `cmake ..` *(fails: cannot find Qt5)*

------
https://chatgpt.com/codex/tasks/task_e_688cd0a1ff94832eba1e7dad56737542